### PR TITLE
Fix deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,14 @@ For local development:
 > npm start
 ```
 
-To publish a new version to GitHub pages:
+To build locally and preview (e.g. before deploying), use
+
+```bash
+> npm run build
+> npm run preview
+```
+
+To publish the current local version to GitHub pages:
 
 ```bash
 > npm run deploy

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "build": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
-    "predeploy": "vite build",
-    "deploy": "gh-pages -d build"
+    "predeploy": "npm run build",
+    "deploy": "gh-pages -d dist"
   },
   "dependencies": {
     "bootstrap": "^5.3.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import MaterialsCloudHeader from "mc-react-header";
 
-import { urlBase } from "./common/config";
+import { URL_BASE } from "./common/config";
 
 import Header from "./components/Header";
 import SsspApp from "./SsspApp";
@@ -26,7 +26,7 @@ const App = () => (
       doi_ids={["f3-ym"]}
       logo={logo}
     />
-    <SsspApp urlBase={urlBase} />
+    <SsspApp urlBase={URL_BASE} />
   </MaterialsCloudHeader>
 );
 

--- a/src/SsspApp/plotting/BandsChessboardPlots/BandsChessboardPlots.tsx
+++ b/src/SsspApp/plotting/BandsChessboardPlots/BandsChessboardPlots.tsx
@@ -1,7 +1,7 @@
 import { BandsChessboardPlotsProps } from "./BandsChessboardPlots.models";
 import styles from "./BandsChessboardPlots.module.scss";
 
-const ROOT = `/discover/sssp/src/SsspApp/data/chessboards`;
+import { IMAGE_DATA_BASE_URL } from "../../../common/config";
 
 const BandsChessboardPlots: React.FC<BandsChessboardPlotsProps> = ({
   element,
@@ -9,11 +9,11 @@ const BandsChessboardPlots: React.FC<BandsChessboardPlotsProps> = ({
   // activeAccuracy,
 }) => {
   const filename = (elementData.chessboards_filenames || []) as string[];
-  const source = `${ROOT}/${filename}`;
+  const source = `${IMAGE_DATA_BASE_URL}/chessboards/${filename}`;
 
   return (
     <div className={styles["chessboard-plot"]}>
-      <img src={source} alt={`Bands chessboard plotsfor ${element}`} />
+      <img src={source} alt={`Bands chessboard plots for ${element}`} />
     </div>
   );
 };

--- a/src/SsspApp/plotting/BandsChessboardPlots/BandsChessboardPlots.tsx
+++ b/src/SsspApp/plotting/BandsChessboardPlots/BandsChessboardPlots.tsx
@@ -6,7 +6,7 @@ const ROOT = `/discover/sssp/src/SsspApp/data/chessboards`;
 const BandsChessboardPlots: React.FC<BandsChessboardPlotsProps> = ({
   element,
   elementData,
-  activeAccuracy,
+  // activeAccuracy,
 }) => {
   const filename = (elementData.chessboards_filenames || []) as string[];
   const source = `${ROOT}/${filename}`;

--- a/src/SsspApp/plotting/OverviewPlots/OverviewPlots.tsx
+++ b/src/SsspApp/plotting/OverviewPlots/OverviewPlots.tsx
@@ -7,7 +7,7 @@ import { ElementDataResponse } from "@sssp/services/models";
 import { OverviewPlotsProps } from "./OverviewPlots.models";
 import styles from "./OverviewPlots.module.scss";
 
-const ROOT = `/discover/sssp/src/SsspApp/data/convergences`;
+import { IMAGE_DATA_BASE_URL } from "../../../common/config";
 
 const OverviewPlots: React.FC<OverviewPlotsProps> = ({
   element,
@@ -37,7 +37,7 @@ const OverviewPlots: React.FC<OverviewPlotsProps> = ({
           {filenames.map((filename, index) => {
             const convergence = filename.split("_")[1];
             const title = `Convergence ${activeAccuracy} - ${convergence}`;
-            const source = `${ROOT}_${activeAccuracy}/${filename}`;
+            const source = `${IMAGE_DATA_BASE_URL}/convergences_${activeAccuracy}/${filename}`;
             return (
               <Tab eventKey={index} title={title} key={index}>
                 <Card.Body className="overview-card">

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -1,1 +1,5 @@
-export const urlBase = "discover/sssp";
+// get the base url subpath from vite.config.ts (base:)
+export const URL_BASE = import.meta.env.BASE_URL || '/';
+
+// raw image data location on github
+export const IMAGE_DATA_BASE_URL = "https://raw.githubusercontent.com/materialscloud-org/discover-sssp-react/refs/heads/main/src/SsspApp/data/"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,8 @@ export default defineConfig({
   server: {
     port: 3000,
   },
-  base: "/discover/sssp/",
+  // Set base path for gh-pages (https://materialscloud-org.github.io/discover-sssp-react/)
+  base: "/discover-sssp-react/",
   resolve: {
     alias: {
       "@sssp": "/src/SsspApp",


### PR DESCRIPTION
hi @edan-bainglass, great work on this.

I checked a bit and got the deployment working here: https://materialscloud-org.github.io/discover-sssp-react/

There were some some issues with the base path and build config, fixed.

But an additional issue was that the 150 MB of image files are included directly in the source code. As they are not directly imported, the build process will not include them in `dist` folder. And including all of them in the frontend (e.g. in the public folder) is not really feasible anyway (it would have to be loaded every time the webpage is accessed).

I currently just directly linked to the raw github URL, when the corresponding data is needed.

Currently i kept the `src` path, just to demonstrate that it works. But probably, this data should be moved out of the `src` folder to something like `static_data`.